### PR TITLE
upgrade from javax dependencies and packages to jakarta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 Introduction to JPA - Source code
 =================================
 
-This project is the sample code for an article called Introduction to JPA
-available that is unfortunately no longer available, but the code its pretty self explanatory.
+This project is the sample code for an article called Introduction to JPA that is unfortunately no longer available, but the code its pretty self explanatory.
 
 The purpose of this fork is to make the example work with the latest migration of JEE javax packages to jakarta.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 Introduction to JPA - Source code
 =================================
 
-This project is the sample code for an article called Introduction to JPA that is unfortunately no longer available, but the code its pretty self explanatory.
-
-The purpose of this fork is to make the example work with the latest migration of JEE javax packages to jakarta.
+This project is the sample code for an article called Introduction to JPA.
 
 This is a Maven project and can be compiled on any computer that
 has JDK 7 and Maven installed.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 Introduction to JPA - Source code
 =================================
 
-This project is the sample code for the article Introduction to JPA
-available here: 
+This project is the sample code for an article called Introduction to JPA
+available that is unfortunately no longer available, but the code its pretty self explanatory.
+
+The purpose of this fork is to make the example work with the latest migration of JEE javax packages to jakarta.
 
 This is a Maven project and can be compiled on any computer that
 has JDK 7 and Maven installed.

--- a/pom.xml
+++ b/pom.xml
@@ -12,13 +12,13 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.eclipse.persistence</groupId>
-			<artifactId>javax.persistence</artifactId>
-			<version>2.1.0</version>
+			<artifactId>jakarta.persistence</artifactId>
+			<version>2.2.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.persistence</groupId>
 			<artifactId>org.eclipse.persistence.jpa</artifactId>
-			<version>2.5.0</version>
+			<version>4.0.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.xerial</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.41.2.2</version>
+			<version>3.7.2</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.7.2</version>
+			<version>3.41.2.2</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/src/main/java/codelook/example/introductiontojpa/jpa/JPATest.java
+++ b/src/main/java/codelook/example/introductiontojpa/jpa/JPATest.java
@@ -2,11 +2,11 @@ package codelook.example.introductiontojpa.jpa;
 
 import java.util.List;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.EntityTransaction;
-import javax.persistence.Persistence;
-import javax.persistence.Query;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.Persistence;
+import jakarta.persistence.Query;
 
 public class JPATest {
 

--- a/src/main/java/codelook/example/introductiontojpa/jpa/Product.java
+++ b/src/main/java/codelook/example/introductiontojpa/jpa/Product.java
@@ -1,7 +1,7 @@
 package codelook.example.introductiontojpa.jpa;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
 
 @Entity
 public class Product {

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -4,8 +4,8 @@
 	    <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
 		<class>codelook.example.introductiontojpa.jpa.Product</class>
 		<properties>
- 			<property name="javax.persistence.jdbc.driver" value="org.sqlite.JDBC" />
-			<property name="javax.persistence.jdbc.url" value="jdbc:sqlite:sample.db" />
+ 			<property name="jakarta.persistence.jdbc.driver" value="org.sqlite.JDBC" />
+			<property name="jakarta.persistence.jdbc.url" value="jdbc:sqlite:sample.db" />
 			<property name="eclipselink.ddl-generation" value="drop-and-create-tables" />
 			<property name="eclipselink.ddl-generation.output-mode" value="database" />
 		</properties>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_1.xsd">
+<persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
 	<persistence-unit name="jpa-test" transaction-type="RESOURCE_LOCAL">
 	    <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
 		<class>codelook.example.introductiontojpa.jpa.Product</class>


### PR DESCRIPTION
After Java EE's transfer over to the Eclipse Foundation, javax.* packages have been renamed to jakarta.*, and so this example no longer works on recent versions of Java. I simply renamed the dependencies and checked that everything still works as before. It would be great if the article that this example supports could be made available again! :)